### PR TITLE
Make TV power optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ Add the accessory in `config.json` in your home directory inside `.homebridge`.
 }
 ```
 
-You also need to enable "mobile tv on" on your tv for the turn on feature to work correctly.
+You also need to enable **mobile tv on** on your tv for the turn on feature to work correctly.
+
+On newer TVs **LG Connect Apps** under the network settings needs to be enabled.
 
 ### Configuration fields
 - `accessory` [required]

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Add the accessory in `config.json` in your home directory inside `.homebridge`.
       "mac": "ab:cd:ef:fe:dc:ba",
       "keyFile": "/home/pi/.homebridge/lgtvKeyFile",
       "pollingEnabled": true,
+      "powerSwitch": true,
       "appSwitch":[
          "com.webos.app.tvguide",
          "youtube.leanback.v4",

--- a/index.js
+++ b/index.js
@@ -406,10 +406,12 @@ webos3Accessory.prototype.setAppSwitchState = function (state, callback, appId) 
 		
 		if (state) {
 			this.log.info('webOS - Trying to launch %s but TV is off, attempting to power on the TV', appId);
-			this.powerOnTvWithCallback(() => {
-				lgtv.request('ssap://system.launcher/launch', {id: appId});
-				callback(null, true);
-			});
+			if(this.powerSwitch) {
+				this.powerOnTvWithCallback(() => {
+					lgtv.request('ssap://system.launcher/launch', {id: appId});
+					callback(null, true);
+				});	
+			}
         }
 		
       //  callback(new Error('webOS - is not connected'))

--- a/index.js
+++ b/index.js
@@ -222,10 +222,10 @@ webos3Accessory.prototype.updateAccessoryStatus = function () {
 
 webos3Accessory.prototype.pollCallback = function (error, status) {
     if (!status) {
-        this.powerService.getCharacteristic(Characteristic.On).updateValue(status);
+        if (this.powerSwitch) this.powerService.getCharacteristic(Characteristic.On).updateValue(status);
         if (this.volumeService) this.volumeService.getCharacteristic(Characteristic.On).updateValue(status);
     } else {
-        this.powerService.getCharacteristic(Characteristic.On).updateValue(status);
+        if (this.powerSwitch) this.powerService.getCharacteristic(Characteristic.On).updateValue(status);
     }
 };
 


### PR DESCRIPTION
In order to hide it from older TVs with webOS versions that don't have the option to wake on lan.
Added the parameter "powerSwitch" in order to handle this, defaults to true.