### PR TITLE
Fix "Device not responding" from Siri

### DIFF
--- a/index.js
+++ b/index.js
@@ -406,7 +406,7 @@ webosTvAccessory.prototype.setState = function(state, callback) {
                 setTimeout(this.checkWakeOnLan.bind(this, callback), 5000);
             })
         } else {
-            callback(null, true);
+            callback();
         }
     } else {
         if (this.connected) {
@@ -416,10 +416,11 @@ webosTvAccessory.prototype.setState = function(state, callback) {
                 this.connected = false;
                 this.setMuteStateManually(null, false);
                 this.setAppSwitchManually(null, false, null);
-                callback(null, true);
+                callback();
             })
         } else {
-            callback(new Error('webOS - is not connected'))
+            // TV is off, we want to turn it off, that's success.
+            callback();
         }
     }
 };
@@ -434,8 +435,12 @@ webosTvAccessory.prototype.setMuteState = function(state, callback) {
         this.lgtv.request('ssap://audio/setMute', {
             mute: !state
         });
-        callback(null, state);
+        callback();
+    } else if (!state) {
+        // TV is off, call it muted.
+        callback();
     } else {
+        // Don't want to turn on the TV and unmute if TV is off.
         callback(new Error('webOS - is not connected'))
     }
 };


### PR DESCRIPTION
Sometimes, Siri says "device is not responding" when setting a scene including the TV, or turning off the TV.

I tracked one cause: when the TV is off, commands to turn it off or mute fail with error.  Instead of causing an error, we should simply succeed if the state is already off.

Also, as far as I can tell from reading HAP-NodeJS code, "set" event callbacks don't take arguments?