### PR TITLE
Update to channel list feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,6 +66,10 @@ class webosTvAccessory {
         if (this.infoButtonAction === undefined || this.infoButtonAction.length === 0) {
             this.infoButtonAction = 'INFO';
         }
+		this.virtualChannelList = config['virtualChannelList'];
+		if (this.virtualChannelList === undefined) {
+			this.virtualChannelList = false;
+		}
 
         // prepare variables
         this.url = 'ws://' + this.ip + ':' + this.port;
@@ -972,7 +976,7 @@ class webosTvAccessory {
                 });
             } else {
                 this.channelButtonService.forEach((tmpChannelButton, i) => {
-                    if (channelNumber === this.channelButtons[i]) {
+                    if (channelNumber === this.channelButtons[i] || channelNumber === this.channelButtons[i].number.toString()) {
                         tmpChannelButton.getCharacteristic(Characteristic.On).updateValue(value);
                     } else {
                         tmpChannelButton.getCharacteristic(Characteristic.On).updateValue(false);

--- a/index.js
+++ b/index.js
@@ -772,9 +772,22 @@ class webosTvAccessory {
 
         this.channelButtonService = new Array();
         this.channelButtons.forEach((value, i) => {
-            this.channelButtons[i] = this.channelButtons[i].toString();
-            let tmpChannel = new Service.Switch(this.name + ' Channel: ' + value, 'channelButtonService' + i);
-            tmpChannel
+			let tmpChannel;
+            if (value.title) {
+				let channelNumber = this.channelButtons[i].number.toString();
+                tmpChannel = new Service.Switch(this.name + ' ' + value.title, 'channelButtonService' + i);
+                tmpChannel
+                .getCharacteristic(Characteristic.On)
+                .on('get', (callback) => {
+                    this.getChannelButtonState(callback, channelNumber);
+                })
+                .on('set', (state, callback) => {
+                    this.setChannelButtonState(state, callback, channelNumber);
+                });
+            } else {
+				this.channelButtons[i] = this.channelButtons[i].toString();
+                tmpChannel = new Service.Switch(this.name + ' Channel: ' + value, 'channelButtonService' + i);
+                tmpChannel
                 .getCharacteristic(Characteristic.On)
                 .on('get', (callback) => {
                     this.getChannelButtonState(callback, this.channelButtons[i]);
@@ -782,6 +795,8 @@ class webosTvAccessory {
                 .on('set', (state, callback) => {
                     this.setChannelButtonState(state, callback, this.channelButtons[i]);
                 });
+            }
+            
 
             this.enabledServices.push(tmpChannel);
             this.channelButtonService.push(tmpChannel);

--- a/index.js
+++ b/index.js
@@ -66,10 +66,6 @@ class webosTvAccessory {
         if (this.infoButtonAction === undefined || this.infoButtonAction.length === 0) {
             this.infoButtonAction = 'INFO';
         }
-		this.virtualChannelList = config['virtualChannelList'];
-		if (this.virtualChannelList === undefined) {
-			this.virtualChannelList = false;
-		}
 
         // prepare variables
         this.url = 'ws://' + this.ip + ':' + this.port;


### PR DESCRIPTION
So, as we discussed before, here are the changes I am proposing (feel free to reject, just showing an example).

Two changes here:

1. Instead of using `[1, 2, 3]` for channelButtons, you can now use `[ { number: 1, title: "Sometitle"}, ... ]` and buttons will have `title` as title instead of `Channel: 1`, `Channel: 2`, etc.

2. On connect to tv, get channel list and store it in `this.channelMap` as `number=>id` map. Later, when switching channel, if `this.channelMap[channelNumber]` exists, try to change channel by id instead of by number (fixed the channel switches not working for me).

Let me know what you think