### PR TITLE
Clarify in config UI that TV must be added explicitly

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -2,8 +2,8 @@
   "pluginAlias": "webostv",
   "pluginType": "platform",
   "singular": true,
-  "headerDisplay": "Homebridge plugin for LG webOS TVs",
-  "footerDisplay": "For a detailed description, see the [README](https://github.com/merdok/homebridge-webos-tv#configuration-1)",
+  "headerDisplay": "Homebridge plugin for LG webOS TVs. The TV must be [added manually](https://github.com/merdok/homebridge-webos-tv#adding-the-tv-to-the-home-app) in the Home app.",
+  "footerDisplay": "For a detailed description, see the [README](https://github.com/merdok/homebridge-webos-tv#configuration-1).",
   "schema": {
     "devices": {
       "title": "Devices",


### PR DESCRIPTION
I installed the plugin via the web UI and this gotcha confused me for a while, until I thought to check the README.

This seems the most visible spot for it. Won't be relevant after first install, but easy enough to skip over.

What do you think?