### PR TITLE
Add luna-message command

### DIFF
--- a/cli/commands/lunaMessage.js
+++ b/cli/commands/lunaMessage.js
@@ -1,0 +1,42 @@
+import * as log from "../log.js";
+import chalk from "chalk";
+import WebosTvHelper from "../../lib/tools/WebosTvHelper.js";
+
+export const command = "luna-message <ip> <mac> <message> <payloadJson>";
+export const description = "Send a message to the Luna bus of the TV";
+export const builder = {
+  timeout: {
+    required: false,
+    alias: "t",
+    type: "number",
+    description: "The call timeout in ms. Default: 5000ms",
+  },
+  debug: {
+    required: false,
+    alias: "d",
+    type: "boolean",
+    description: "Enable debug output",
+  },
+};
+
+export const handler = async (argv) => {
+  const { ip, mac, message, payloadJson, timeout, debug } = argv;
+  const payloadStruct = payloadJson ? JSON.parse(payloadJson) : {};
+
+  try {
+    log.info(
+      `Trying to send the Luna message: ${chalk.green.bold(
+        message
+      )} with payload ${chalk.green.bold(
+        payloadJson
+      )} on the TV (${chalk.yellow(ip)})`
+    );
+    let lgTvCtrl = await WebosTvHelper.connect(ip, mac, debug, timeout);
+    await lgTvCtrl.lunaSend(message, payloadStruct);
+    log.success(`Sent message`);
+  } catch (err) {
+    log.error(err.message);
+  }
+
+  process.exit(0);
+};

--- a/cli/commands/lunaSend.js
+++ b/cli/commands/lunaSend.js
@@ -2,7 +2,7 @@ import * as log from "../log.js";
 import chalk from "chalk";
 import WebosTvHelper from "../../lib/tools/WebosTvHelper.js";
 
-export const command = "luna-message <ip> <mac> <message> <payloadJson>";
+export const command = "luna-send <ip> <mac> <message> <payloadJson>";
 export const description = "Send a message to the Luna bus of the TV";
 export const builder = {
   timeout: {

--- a/cli/index.js
+++ b/cli/index.js
@@ -20,7 +20,7 @@ import * as volume from './commands/volume.js';
 import * as toast from './commands/toast.js';
 import * as app from './commands/app.js';
 import * as settings from './commands/settings.js';
-import * as lunaMessage from './commands/lunaMessage.js';
+import * as lunaSend from './commands/lunaSend.js';
 //import * as tv from './commands/tv.js';
 
 yargs(hideBin(process.argv))
@@ -30,6 +30,6 @@ yargs(hideBin(process.argv))
   .command(toast)
   .command(app)
   .command(settings)
-  .command(lunaMessage)
+  .command(lunaSend)
   .recommendCommands()
   .demandCommand().argv;

--- a/cli/index.js
+++ b/cli/index.js
@@ -20,9 +20,16 @@ import * as volume from './commands/volume.js';
 import * as toast from './commands/toast.js';
 import * as app from './commands/app.js';
 import * as settings from './commands/settings.js';
+import * as lunaMessage from './commands/lunaMessage.js';
 //import * as tv from './commands/tv.js';
 
-yargs(hideBin(process.argv)).command(pair).command(power).command(volume).command(toast).command(app).command(settings)
+yargs(hideBin(process.argv))
+  .command(pair)
+  .command(power)
+  .command(volume)
+  .command(toast)
+  .command(app)
+  .command(settings)
+  .command(lunaMessage)
   .recommendCommands()
-  .demandCommand()
-  .argv;
+  .demandCommand().argv;

--- a/lib/LgTvController.js
+++ b/lib/LgTvController.js
@@ -1119,7 +1119,7 @@ class LgTvController extends EventEmitter {
       uri: lunaService,
       params: params
     };
-    this.openAlert('lunaSend', 'lunaSend', true, buttons, onClose, onFail, 'confirm', true).then((res) => {
+    return this.openAlert('lunaSend', 'lunaSend', true, buttons, onClose, onFail, 'confirm', true).then((res) => {
       if (res && res.alertId && this.getWebOsVersion() >= 4) {
         this.closeAlert(res.alertId); // seems that the close alert service is only available on webos4 or higher
       } else {


### PR DESCRIPTION
Adding a new command that you can use to send direct Luna command to the TV.

Example:

`webostv luna-message <IP> <MAC> luna://org.webosbrew.hbchannel.service/autostart '{}'`

I'm personally going to use this to remotely execute WebosBrew startup that is broken for webOS 4.x - see more [here](https://github.com/kopiro/webosbrew-autostart).

Also, please notice that I fixed a problem in the `lunaSend` method not returning the promise, therefore the script was terminating before the popup was able to being closed.