### PR TITLE
Make sure that live TV channel is never removed

### DIFF
--- a/index.js
+++ b/index.js
@@ -548,21 +548,24 @@ class webosTvDevice {
   }
 
   removeInputSource(inputDef) {
-    // removed it from configured inptuts
-    delete this.configuredInputs[inputDef.id];
+    // never remove live TV ...
+    if (inputDef.appId !== this.lgTvCtrl.getLiveTvAppId())
+    {
+      // removed it from configured inptuts
+      delete this.configuredInputs[inputDef.id];
 
-    // reset dummy info
-    let inputService = inputDef.inputService;
-    inputService
-      .setCharacteristic(Characteristic.Name, 'dummy')
-      .setCharacteristic(Characteristic.ConfiguredName, 'dummy')
-      .setCharacteristic(Characteristic.IsConfigured, Characteristic.IsConfigured.NOT_CONFIGURED)
-      .setCharacteristic(Characteristic.TargetVisibilityState, Characteristic.TargetVisibilityState.HIDDEN)
-      .setCharacteristic(Characteristic.CurrentVisibilityState, Characteristic.CurrentVisibilityState.HIDDEN);
+      // reset dummy info
+      let inputService = inputDef.inputService;
+      inputService
+        .setCharacteristic(Characteristic.Name, 'dummy')
+        .setCharacteristic(Characteristic.ConfiguredName, 'dummy')
+        .setCharacteristic(Characteristic.IsConfigured, Characteristic.IsConfigured.NOT_CONFIGURED)
+        .setCharacteristic(Characteristic.TargetVisibilityState, Characteristic.TargetVisibilityState.HIDDEN)
+        .setCharacteristic(Characteristic.CurrentVisibilityState, Characteristic.CurrentVisibilityState.HIDDEN);
 
-    // readd to the dummy list as free
-    this.dummyInputSourceServices.push(inputService);
-
+      // readd to the dummy list as free
+      this.dummyInputSourceServices.push(inputService);  
+    }
   }
 
 

--- a/lib/LgTvController.js
+++ b/lib/LgTvController.js
@@ -259,6 +259,7 @@ class LgTvController extends EventEmitter {
     tvInfoPromises.push(this.getLaunchPoints().then((res) => {
       if (res && res.launchPoints && Array.isArray(res.launchPoints)) {
         this.launchPointsList = this.parseLaunchPoints(res.launchPoints);
+        this.checkBasicInputs();
         this.logDebug('Retrieved launch points (inputs, apps)');
         this.logDeepDebug(JSON.stringify(this.launchPointsList, null, 2));
       } else {


### PR DESCRIPTION
This fix is to avoid the removal of  the LiveTv checkpoint that sometimes occurs during the plugin init